### PR TITLE
Added auth guards to prevent unauthorized access and modified auth.service.ts

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -4,26 +4,36 @@ import { LoginComponent } from './login/login.component';
 import { ForgotPassComponent } from './forgot-pass/forgot-pass.component';
 import { DashboardComponent } from './dashboard/dashboard.component';
 import { InventoryComponent } from './inventory/inventory.component';
+import { authGuard } from './auth.guard'; //Return true if logged in
+import { authLoggedInGuard } from './auth-logged-in.guard'; //Return true if not logged in
+import { authManagerGuard } from './auth-manager.guard'; //For routes that are for managers only -> Return true if manager
+
 export const routes: Routes = [
     {
     path: "",
     component: LoginComponent,
-    title: "Login"
+    title: "Login",
+    canActivate: [authLoggedInGuard], //Logged in users can't access login page
+
     },
     {   
         path: 'forgotPass',
         component: ForgotPassComponent,
-        title: 'Forgot Password'
+        title: 'Forgot Password',
+        canActivate: [authLoggedInGuard], //Logged in users can't access forgot password page
+  
     },
     {
         path: 'dashboard',
         component: DashboardComponent,
-        title: 'Dashboard'
+        title: 'Dashboard',
+        canActivate: [authGuard] //Logged out users can't access dashboard
     },
     {
         path: 'inventory',
         component: InventoryComponent,
-        title: 'Inventory'
+        title: 'Inventory',
+        canActivate: [authGuard] //Logged out users can't access inventory
     }
 
 

--- a/src/app/auth-logged-in.guard.spec.ts
+++ b/src/app/auth-logged-in.guard.spec.ts
@@ -1,0 +1,17 @@
+import { TestBed } from '@angular/core/testing';
+import { CanActivateFn } from '@angular/router';
+
+import { authLoggedInGuard } from './auth-logged-in.guard';
+
+describe('authLoggedInGuard', () => {
+  const executeGuard: CanActivateFn = (...guardParameters) => 
+      TestBed.runInInjectionContext(() => authLoggedInGuard(...guardParameters));
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+  });
+
+  it('should be created', () => {
+    expect(executeGuard).toBeTruthy();
+  });
+});

--- a/src/app/auth-logged-in.guard.ts
+++ b/src/app/auth-logged-in.guard.ts
@@ -1,0 +1,19 @@
+import { CanActivateFn, Router } from '@angular/router';
+import { AuthService } from './auth.service';
+import { inject } from '@angular/core';
+
+
+
+export const authLoggedInGuard: CanActivateFn = (route, state) => {
+const router = inject(Router);
+const auth = inject(AuthService);
+
+
+
+//Redirect a logged in user away from login page and forgot password
+if (auth.loggedIn()){
+  router.navigate(['/dashboard']);
+  return false;
+}
+else return true;
+};

--- a/src/app/auth-manager.guard.spec.ts
+++ b/src/app/auth-manager.guard.spec.ts
@@ -1,0 +1,17 @@
+import { TestBed } from '@angular/core/testing';
+import { CanActivateFn } from '@angular/router';
+
+import { authManagerGuard } from './auth-manager.guard';
+
+describe('authManagerGuard', () => {
+  const executeGuard: CanActivateFn = (...guardParameters) => 
+      TestBed.runInInjectionContext(() => authManagerGuard(...guardParameters));
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+  });
+
+  it('should be created', () => {
+    expect(executeGuard).toBeTruthy();
+  });
+});

--- a/src/app/auth-manager.guard.ts
+++ b/src/app/auth-manager.guard.ts
@@ -1,0 +1,15 @@
+import { CanActivateFn, Router } from '@angular/router';
+import { AuthService } from './auth.service';
+import { inject } from '@angular/core';
+
+
+export const authManagerGuard: CanActivateFn = (route, state) => {
+  const router = inject(Router);
+  const authservice = inject(AuthService);
+
+  //Prevent employees from access manager only routes
+  if (authservice.isManager())
+    return true;
+  else
+    return false;
+};

--- a/src/app/auth.guard.spec.ts
+++ b/src/app/auth.guard.spec.ts
@@ -1,0 +1,17 @@
+import { TestBed } from '@angular/core/testing';
+import { CanActivateFn } from '@angular/router';
+
+import { authGuard } from './auth.guard';
+
+describe('authGuard', () => {
+  const executeGuard: CanActivateFn = (...guardParameters) => 
+      TestBed.runInInjectionContext(() => authGuard(...guardParameters));
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+  });
+
+  it('should be created', () => {
+    expect(executeGuard).toBeTruthy();
+  });
+});

--- a/src/app/auth.guard.ts
+++ b/src/app/auth.guard.ts
@@ -1,0 +1,15 @@
+import { CanActivateFn, Router } from '@angular/router';
+import { AuthService } from './auth.service';
+import { inject } from '@angular/core';
+
+export const authGuard: CanActivateFn = (route, state) => {
+  const router = inject(Router);
+  const authservice = inject(AuthService);
+
+  if (authservice.loggedIn())
+  return true;
+else{
+  router.navigate([""]);
+  return false;
+}
+};

--- a/src/app/auth.service.ts
+++ b/src/app/auth.service.ts
@@ -9,9 +9,9 @@ import { Router } from '@angular/router';;
   providedIn: 'root'
 })
 export class AuthService {
-  //onAuthStateChange will prevent refreshing from setting currentUser to null
+
   constructor() {}
-  
+
   private firebaseAuth = inject(Auth);
   private firestore = inject(Firestore);
   private router = inject(Router);
@@ -89,7 +89,7 @@ resetPassword(email: string){
     .catch(err => alert('Error sending reset link: ' + err.message));
 }
 
-//Return true if the current user is not set to null, else false
+//Return true if the current user is valid via local storage token
 loggedIn(){
   return localStorage.getItem('token') == 'true'
 }

--- a/src/app/auth.service.ts
+++ b/src/app/auth.service.ts
@@ -2,16 +2,16 @@ import { Injectable, inject } from '@angular/core';
 import { Auth, signInWithEmailAndPassword, sendPasswordResetEmail } from '@angular/fire/auth';
 import { doc, Firestore, getDoc, collection, query, where, getDocs } from '@angular/fire/firestore';
 import { User } from './user';
-import { Router } from '@angular/router';
+import { Router } from '@angular/router';;
 
 
 @Injectable({
   providedIn: 'root'
 })
 export class AuthService {
-
-  constructor() { }
-
+  //onAuthStateChange will prevent refreshing from setting currentUser to null
+  constructor() {}
+  
   private firebaseAuth = inject(Auth);
   private firestore = inject(Firestore);
   private router = inject(Router);
@@ -21,6 +21,7 @@ export class AuthService {
 async login(email: string, password:string): Promise<void>{
 
   try{
+   
 //Sign In and save the UID that matches with the user's login information
 const credential = await signInWithEmailAndPassword(this.firebaseAuth, email, password);
 const uid = credential.user.uid;
@@ -49,6 +50,7 @@ const AppUser: User = {
 // Add the 'role' to local storage
 localStorage.setItem('role', role);
 localStorage.setItem('user', JSON.stringify(AppUser))
+localStorage.setItem('token', 'true');
 
 //Route the user to the dashboard if the user successfully logs in
   this.router.navigate(['/dashboard']);
@@ -87,7 +89,18 @@ resetPassword(email: string){
     .catch(err => alert('Error sending reset link: ' + err.message));
 }
 
+//Return true if the current user is not set to null, else false
 loggedIn(){
-  return this.firebaseAuth.currentUser !== null;
+  return localStorage.getItem('token') == 'true'
+}
+
+//Return True if user is a manager
+isManager(){
+  return localStorage.getItem('role') == "MANAGER";
+}
+
+//Return True if user is an employee
+isEmployee(){
+  return localStorage.getItem('role') == 'EMPLOYEE';
 }
 }

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -1,4 +1,6 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
+import { AuthService } from '../auth.service';
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'app-dashboard',
@@ -7,5 +9,12 @@ import { Component } from '@angular/core';
   styleUrl: './dashboard.component.css'
 })
 export class DashboardComponent {
+private auth = inject(AuthService);
+private router = inject(Router);
+
+//For dynamic display manager's views away from employees
+isManager(){
+return this.auth.isManager();
+}
 
 }


### PR DESCRIPTION
These auth guards prevent unauthorized access into the different pages via direct URL or links within the page. I also modified and simplified auth.service.ts, removing OnAuthStateChanged and changed the LoggedIn() function to utilize localstorage tokens rather than currentUser, preventing forced redirect to login page after refreshing the tab caused by auth guards being ran before OnAuthStateChanged